### PR TITLE
Treu les barres d'scroll de la caixa de text traduït

### DIFF
--- a/maqueta/app/assets/less/layouts/layout-eines.less
+++ b/maqueta/app/assets/less/layouts/layout-eines.less
@@ -296,7 +296,7 @@ LAYOUT - eines
 					font-weight: 300;
 					line-height: 1.7;
 					resize: none;
-					overflow: scroll;
+					overflow: auto;
 				}
 				.second-textarea:focus {
 					border: none;


### PR DESCRIPTION
No he compilat el CSS i no he pogut provar aquest canvi perquè no he trobat documentació sobre com fer-ho. Però el canvi és prou senzill. Amb aquesta modificació, s'amaguen les barres d'scroll a la caixa de "resultat" del traductor.

Actualment sempre es mostren la barra vertical i horitzontal. Amb aquesta PR quan el text és curt no es mostra cap barra d'scroll i quan el text és llarg, només es mostra la barra vertical.

**Text curt**
Abans:
![image](https://cloud.githubusercontent.com/assets/3616980/23808559/97d66884-05ca-11e7-91a0-6fda851a8afd.png)

Després:
![image](https://cloud.githubusercontent.com/assets/3616980/23808681/fd4b6976-05ca-11e7-9d92-37753de341ed.png)


**Text llarg**
Abans:
![image](https://cloud.githubusercontent.com/assets/3616980/23808506/6ad0140c-05ca-11e7-9ba1-5bb093c43fd3.png)

Després:
![image](https://cloud.githubusercontent.com/assets/3616980/23808491/5ba6f00e-05ca-11e7-8a5a-ddf532dc49b2.png)