### PR TITLE
Usa el logo sense llaç, i amb més resolució.

### DIFF
--- a/ssi/menu-header.html
+++ b/ssi/menu-header.html
@@ -46,7 +46,7 @@
                   </button>
                   </a>
                 </div>
-                <a class="navbar-brand" rel="home" href="/"><img alt="Softcatala logotip" src="/themes/wp-softcatala/static/images/softcatala-logo-groc.png"></a>
+                <a class="navbar-brand" rel="home" href="/"><img height="90" width="146" alt="Logotip Softcatalà" src="/themes/wp-softcatala/static/images/softcatala-logotip.png"></a>
               </div><!--/.navbar-header -->
 
 


### PR DESCRIPTION
Depèn de https://github.com/Softcatala/wp-softcatala/pull/287/files