### PR TITLE
Remove Windows Phone as filter in the search

### DIFF
--- a/conf/wordpress/acf.json
+++ b/conf/wordpress/acf.json
@@ -241,7 +241,6 @@
                             "linux": "Linux",
                             "ios": "iOS",
                             "android": "Android",
-                            "windows_phone": "Windows Phone",
                             "multiplataforma": "Multiplataforma",
                             "web": "Web"
                         },


### PR DESCRIPTION
Ep @xavivars @lequims 

A https://www.softcatala.org/programes/ cal llevar 'Windows Phone' com a filtre en el SO ja que el sistema no existeix i no tenim fitxer. Ho he intentat fer eliminant això però en local no m'ho lleva. No sé si cal tocar-ho en altre lloc o és un tema de caches.