### PR TITLE
Afegeix padding i treu negretes de la caixa inferior del traductor

### DIFF
--- a/maqueta/app/assets/less/layouts/layout-eines.less
+++ b/maqueta/app/assets/less/layouts/layout-eines.less
@@ -350,7 +350,6 @@ LAYOUT - eines
 		.traductor-checkbox{
             background-color: @fons-menu;
             margin: 15px 0;
-            font-weight: 600;
             font-size: 13px;
             padding: 30px 0;
             a{
@@ -389,7 +388,6 @@ LAYOUT - eines
 				.checkbox-inline {
 				    float: right;
 				    font-size: 13px;
-				    font-weight: 600;
 				    margin-right: 10px;
 				}
 				@media (max-width: @screen-sm) {

--- a/maqueta/app/assets/less/layouts/layout-eines.less
+++ b/maqueta/app/assets/less/layouts/layout-eines.less
@@ -349,12 +349,10 @@ LAYOUT - eines
 
 		.traductor-checkbox{
             background-color: @fons-menu;
-			margin-top:15px;
-			margin-bottom: 15px;
-            margin-left: 0px;
-            margin-right: 0px;
+            margin: 15px 0;
             font-weight: 600;
             font-size: 13px;
+            padding: 30px 0;
             a{
                 cursor: pointer
             }
@@ -369,7 +367,6 @@ LAYOUT - eines
             }
 
             .icon-inline {
-                padding-top: 7px;
                 display: inline-block;
                 padding-bottom: 7px;
                 cursor: pointer;


### PR DESCRIPTION
Aquesta PR és un petit suggeriment per a la interfície del traductor que:

* Afegeix padding superior i inferior a la caixa inferior del traductor: l'objectiu és que el text sigui més fàcil de llegir en estar més allunyat del marge.
* Treu les negretes de les opcions d'aquesta caixa: el raonament és que aquestes opcions no són l'element de l'UI més important de la pàgina, per tant, no hi ha cap motiu per destacar-los amb negreta per sobre la resta.

`master` | Aquesta branca
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/201489058-b17224f1-7521-40a1-bce2-b30e3f2dc9f6.png) | ![imatge](https://user-images.githubusercontent.com/3616980/201489073-2c4462b1-a11a-4571-9319-9950a4249e5e.png)

Els canvis estan en dos commits diferents, per si n'hi ha algun que vulgueu revertir.